### PR TITLE
Hbase dynamic column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.github.maanaim</groupId>
   <artifactId>hbase-om</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <name>HBase Object Mapper</name>
   <description>A little Java-annotation based compact utility library for HBase that helps you:
     [1] convert objects of your bean-like classes to HBase rows.

--- a/src/main/java/io/github/maanaim/hbaseom/annotation/HBaseArrayColumnFamily.java
+++ b/src/main/java/io/github/maanaim/hbaseom/annotation/HBaseArrayColumnFamily.java
@@ -1,0 +1,39 @@
+package io.github.maanaim.hbaseom.annotation;
+
+import io.github.maanaim.hbaseom.mapper.HBaseFormat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation must be used when the column family uses the qualifier dynamically, so the column family will be
+ * an array as key/value
+ * */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value= ElementType.FIELD)
+public @interface HBaseArrayColumnFamily {
+
+    /**
+     * String used to load the column family
+     *
+     * @var String family
+     * */
+    String family();
+
+    /**
+     * Main format to convert the qualifier data
+     *
+     * @var io.github.maanaim.hbaseom.mapper.HBaseFormat
+     * */
+    HBaseFormat qualifierFormat() default HBaseFormat.DEFAULT;
+
+    /**
+     * Main format to convert the value data
+     *
+     * @var io.github.maanaim.hbaseom.mapper.HBaseFormat
+     * */
+    HBaseFormat valueFormat() default HBaseFormat.DEFAULT;
+
+}

--- a/src/main/java/io/github/maanaim/hbaseom/annotation/HBaseArrayColumnFamily.java
+++ b/src/main/java/io/github/maanaim/hbaseom/annotation/HBaseArrayColumnFamily.java
@@ -23,11 +23,21 @@ public @interface HBaseArrayColumnFamily {
     String family();
 
     /**
+     * The type to convert qualifier value
+     * */
+    String qualifierType() default "String";
+
+    /**
      * Main format to convert the qualifier data
      *
      * @var io.github.maanaim.hbaseom.mapper.HBaseFormat
      * */
     HBaseFormat qualifierFormat() default HBaseFormat.DEFAULT;
+
+    /**
+     * The type to convert the value
+     * */
+    String valueType() default "String";
 
     /**
      * Main format to convert the value data

--- a/src/main/java/io/github/maanaim/hbaseom/annotation/HBaseArrayColumnFamily.java
+++ b/src/main/java/io/github/maanaim/hbaseom/annotation/HBaseArrayColumnFamily.java
@@ -18,31 +18,41 @@ public @interface HBaseArrayColumnFamily {
     /**
      * String used to load the column family
      *
-     * @var String family
+     * String family
+     *
+     * @return String
      * */
     String family();
 
     /**
      * The type to convert qualifier value
+     *
+     * @return String
      * */
     String qualifierType() default "String";
 
     /**
      * Main format to convert the qualifier data
      *
-     * @var io.github.maanaim.hbaseom.mapper.HBaseFormat
+     * io.github.maanaim.hbaseom.mapper.HBaseFormat
+     *
+     * @return HBaseFormat
      * */
     HBaseFormat qualifierFormat() default HBaseFormat.DEFAULT;
 
     /**
      * The type to convert the value
+     *
+     * @return String
      * */
     String valueType() default "String";
 
     /**
      * Main format to convert the value data
      *
-     * @var io.github.maanaim.hbaseom.mapper.HBaseFormat
+     * io.github.maanaim.hbaseom.mapper.HBaseFormat
+     *
+     * @return HBaseFormat
      * */
     HBaseFormat valueFormat() default HBaseFormat.DEFAULT;
 

--- a/src/main/java/io/github/maanaim/hbaseom/converter/exceptions/WrongAttributeTypeException.java
+++ b/src/main/java/io/github/maanaim/hbaseom/converter/exceptions/WrongAttributeTypeException.java
@@ -1,0 +1,11 @@
+package io.github.maanaim.hbaseom.converter.exceptions;
+
+public class WrongAttributeTypeException extends Exception {
+
+    public WrongAttributeTypeException(String mustBe, String sent ) {
+        super(
+                "The attribute type must be [ " + mustBe + "] but was sent [ " + sent + " ]! "
+        );
+    }
+
+}


### PR DESCRIPTION
**HBaseArrayColumnFamily** was added. This note should be used when using the Hbase qualifier as an additional key value. Modifications were also made to the methods of class **AbstractHBaseDao** to adapt to the new annotation.

A new exception has also been added, **WrongAttributeTypeException**. Since we will always return a Map of **HBaseArrayColumnFamily**, we soon need to ensure that the attribute is of type Map always.